### PR TITLE
Replace the method used to inject the GameProfile.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,13 @@
       <id>spigotmc</id>
       <url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
     </repository>
+    <repository>
+      <id>mojang</id>
+      <url>https://libraries.minecraft.net/</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
   </repositories>
   
   <dependencies>
@@ -44,6 +51,12 @@
       <groupId>org.spigotmc</groupId>
       <artifactId>spigot-api</artifactId>
       <version>1.10-R0.1-SNAPSHOT</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.mojang</groupId>
+      <artifactId>authlib</artifactId>
+      <version>1.5.22</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/lilypad/bukkit/connect/injector/PacketInjector.java
+++ b/src/main/java/lilypad/bukkit/connect/injector/PacketInjector.java
@@ -12,6 +12,7 @@ import javassist.NotFoundException;
 import javassist.expr.ExprEditor;
 import javassist.expr.MethodCall;
 import lilypad.bukkit.connect.ConnectPlugin;
+import lilypad.bukkit.connect.util.JavassistUtil;
 import lilypad.bukkit.connect.util.ReflectionUtils;
 
 import org.bukkit.Server;
@@ -39,7 +40,7 @@ public class PacketInjector {
 		}
 		Class<?> packetClass = (Class<?>) serverBound.get(packetId);
 		// create packet proxy
-		ClassPool classPool = ClassPool.getDefault();
+		ClassPool classPool = JavassistUtil.getClassPool();
 		CtClass packetCtClass = classPool.getCtClass(packetClass.getName());
 		final CtClass packetCtClassProxy = classPool.getAndRename(packetClass.getName(), packetClass.getName() + "$stringMaxSize" + maxSize);
 		packetCtClassProxy.setSuperclass(packetCtClass);
@@ -52,8 +53,8 @@ public class PacketInjector {
 		CtMethod decodeCtMethod = packetCtClassProxy.getDeclaredMethod(ConnectPlugin.getProtocol().getPacketInjectorDecodeCtMethod(), new CtClass[] { classPool.getCtClass(minecraftPackage + ".PacketDataSerializer") });
 		decodeCtMethod.instrument(new ExprEditor() {
 			public void edit(MethodCall methodCall) throws CannotCompileException {
-				if(!methodCall.getClassName().equals(minecraftPackage + ".PacketDataSerializer") 
-						|| !methodCall.getMethodName().equals("c") 
+				if(!methodCall.getClassName().equals(minecraftPackage + ".PacketDataSerializer")
+						|| !methodCall.getMethodName().equals("c")
 						|| !methodCall.getSignature().equals("(I)Ljava/lang/String;")) {
 					return;
 				}
@@ -74,5 +75,5 @@ public class PacketInjector {
 		// replace packet
 		serverBound.put(packetId, packetClassProxy);
 	}
-	
+
 }

--- a/src/main/java/lilypad/bukkit/connect/login/LoginListenerProxy.java
+++ b/src/main/java/lilypad/bukkit/connect/login/LoginListenerProxy.java
@@ -105,6 +105,10 @@ public class LoginListenerProxy {
         return packetListenerField;
     }
 
+    public static Class getLoginListenerClass() {
+        return loginListenerClass;
+    }
+
     public static Field getProfileField() {
         return profileField;
     }

--- a/src/main/java/lilypad/bukkit/connect/login/LoginListenerProxy.java
+++ b/src/main/java/lilypad/bukkit/connect/login/LoginListenerProxy.java
@@ -1,0 +1,111 @@
+package lilypad.bukkit.connect.login;
+
+import com.mojang.authlib.GameProfile;
+import javassist.*;
+import javassist.bytecode.*;
+import lilypad.bukkit.connect.util.JavassistUtil;
+
+import java.lang.reflect.Field;
+
+public class LoginListenerProxy {
+    private static Class instance;
+    private static Field packetListenerField;
+
+    private static Class loginListenerClass;
+    private static Field profileField;
+
+    private static Field findFieldOfType(Class type, Class fieldType) {
+        for (Field field : type.getDeclaredFields()) {
+            if (field.getType() == fieldType) {
+                field.setAccessible(true);
+                return field;
+            }
+        }
+        return null;
+    }
+
+    private static Class create(Object networkManager) throws Exception {
+        Object originalLoginListener = null;
+        packetListenerField = null;
+        Field[] networkManagerFields = networkManager.getClass().getDeclaredFields();
+        for (Field field : networkManagerFields) {
+            if (field.getType().getSimpleName().equals("PacketListener")) {
+                field.setAccessible(true);
+                packetListenerField = field;
+                originalLoginListener = field.get(networkManager);
+                break;
+            }
+        }
+
+
+        if (originalLoginListener == null || !originalLoginListener.getClass().getSimpleName().equals("LoginListener")) {
+            throw new Exception("Could not find LoginListener in NetworkManager!");
+        }
+
+        loginListenerClass = originalLoginListener.getClass();
+        profileField = findFieldOfType(loginListenerClass, GameProfile.class);
+
+        Class<?> loginListenerClass = originalLoginListener.getClass();
+
+        ClassPool classPool = JavassistUtil.getClassPool();
+        CtClass loginListenerCtClass = classPool.getCtClass(loginListenerClass.getName());
+        CtClass loginListenerProxyCtClass = classPool.makeClass(loginListenerClass.getName() + "$UuidInjector", loginListenerCtClass);
+
+        loginListenerProxyCtClass.setSuperclass(loginListenerCtClass);
+
+        CtConstructor loginListenerConstructor = loginListenerCtClass.getDeclaredConstructors()[0];
+
+        CtConstructor loginListenerProxyCtConstructor = new CtConstructor(loginListenerConstructor.getParameterTypes(), loginListenerProxyCtClass);
+        loginListenerProxyCtConstructor.setBody("{ super($$); }");
+        loginListenerProxyCtClass.addConstructor(loginListenerProxyCtConstructor);
+
+        loginListenerProxyCtClass.addField(CtField.make("public java.lang.Runnable injectUuidCallback;", loginListenerProxyCtClass));
+
+        CtMethod initUuidMethod = null;
+        for (CtMethod method : loginListenerCtClass.getMethods()) {
+            MethodInfo methodInfo = method.getMethodInfo();
+            ConstPool constPool = methodInfo.getConstPool();
+            CodeAttribute codeAttribute = methodInfo.getCodeAttribute();
+            if (codeAttribute == null) {
+                continue;
+            }
+            CodeIterator code = codeAttribute.iterator();
+            while (code.hasNext()) {
+                int index = code.next();
+                if (code.byteAt(index) == Opcode.LDC) {
+                    int cstIndex = code.byteAt(index + 1);
+                    if (constPool.getTag(cstIndex) == 8) {
+                        if (constPool.getStringInfo(cstIndex).equals("OfflinePlayer:")) {
+                            initUuidMethod = method;
+                        }
+                    }
+                }
+            }
+        }
+
+        if (initUuidMethod == null) {
+            throw new Exception("Could not find initUUID in LoginListener!");
+        }
+
+        CtMethod newMethod = new CtMethod(initUuidMethod.getReturnType(), initUuidMethod.getName(), initUuidMethod.getParameterTypes(), loginListenerProxyCtClass);
+        newMethod.setBody("{ this.injectUuidCallback.run(); }");
+        loginListenerProxyCtClass.addMethod(newMethod);
+
+        return loginListenerProxyCtClass.toClass();
+    }
+
+    public static synchronized Class get(Object networkManager) throws Exception {
+        if (instance == null) {
+            instance = create(networkManager);
+        }
+        return instance;
+    }
+
+    public static Field getPacketListenerField() {
+        return packetListenerField;
+    }
+
+    public static Field getProfileField() {
+        return profileField;
+    }
+}

--- a/src/main/java/lilypad/bukkit/connect/login/LoginNettyInjectHandler.java
+++ b/src/main/java/lilypad/bukkit/connect/login/LoginNettyInjectHandler.java
@@ -1,128 +1,185 @@
 package lilypad.bukkit.connect.login;
 
+import com.mojang.authlib.GameProfile;
+import com.mojang.authlib.properties.Property;
 import io.netty.channel.AbstractChannel;
 import io.netty.channel.ChannelHandlerContext;
-
-import java.lang.reflect.Field;
-import java.net.InetSocketAddress;
-
 import lilypad.bukkit.connect.ConnectPlugin;
 import lilypad.bukkit.connect.injector.NettyDecoderHandler;
 import lilypad.bukkit.connect.injector.NettyInjectHandler;
+import lilypad.bukkit.connect.injector.OfflineInjector;
 import lilypad.bukkit.connect.util.ReflectionUtils;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.net.InetSocketAddress;
+import java.util.UUID;
 
 public class LoginNettyInjectHandler implements NettyInjectHandler {
 
-	private String requestedStateFieldCache;
-	private String serverHostFieldCache;
-	
-	private ConnectPlugin connectPlugin;
-	private LoginPayloadCache payloadCache;
-	
-	public LoginNettyInjectHandler(ConnectPlugin connectPlugin, LoginPayloadCache payloadCache) {
-		this.connectPlugin = connectPlugin;
-		this.payloadCache = payloadCache;
-	}
-	
-	public void packetReceived(NettyDecoderHandler handler, ChannelHandlerContext context, Object object) throws Exception {
-		if(!object.getClass().getSimpleName().startsWith("PacketHandshakingInSetProtocol")) {
-			return;
-		}
-		handler.setEnabled(false);
-		
-		// Get requested state
-		try {
-			if(this.requestedStateFieldCache == null) {
-				for(Field field : object.getClass().getDeclaredFields()) {
-					if(!field.getType().getSimpleName().equals("EnumProtocol")) {
-						continue;
-					}
-					this.requestedStateFieldCache = field.getName();
-					break;
-				}
-			}
-			Object requestedStateEnum = ReflectionUtils.getPrivateField(object.getClass(), object, Object.class, this.requestedStateFieldCache);
-			if(requestedStateEnum.toString().equals("STATUS")) {
-				return;
-			}
-		} catch(Exception exception) {
-			exception.printStackTrace();
-			context.close();
-			return;
-		}
-		
-		// Get server host
-		String serverHost;
-		try {
-			if(this.serverHostFieldCache == null) {
-				for(Field field : object.getClass().getSuperclass().getDeclaredFields()) {
-					if(!field.getType().getSimpleName().equals("String")) {
-						continue;
-					}
-					this.serverHostFieldCache = field.getName();
-					break;
-				}
-			}
-			serverHost = ReflectionUtils.getPrivateField(object.getClass().getSuperclass(), object, String.class, this.serverHostFieldCache);
-		} catch(Exception exception) {
-			exception.printStackTrace();
-			context.close();
-			return;
-		}
-		
-		// Get login payload
-		LoginPayload payload;
-		try {
-			payload = LoginPayload.decode(serverHost);
-			if(payload == null) {
-				throw new Exception(); // for lack of a better solution
-			}
-		} catch(Exception exception) {
-			context.close();
-			return;
-		}
-		
-		// Check the security key
-		if(!payload.getSecurityKey().equals(this.connectPlugin.getSecurityKey())) {
-			// TODO tell the client the security key failed?
-			context.close();
-			return;
-		}
-		
-		// Store the host
-		try {
-			ReflectionUtils.setFinalField(object.getClass().getSuperclass(), object, this.serverHostFieldCache, payload.getHost());
-		} catch(Exception exception) {
-			exception.printStackTrace();
-		}
-		
-		// Store the real ip & port
-		try {
-			InetSocketAddress newRemoteAddress = new InetSocketAddress(payload.getRealIp(), payload.getRealPort());
-			// Netty
-			ReflectionUtils.setFinalField(AbstractChannel.class, context.channel(), "remoteAddress", newRemoteAddress);
-			// MC
-			Object networkManager = context.channel().pipeline().get("packet_handler");
-			if (ConnectPlugin.getProtocol().getGeneralVersion().equalsIgnoreCase("1.7")) {
-				String[] fields = ConnectPlugin.getProtocol().getLoginNettyInjectHandlerNetworkManager().split(",");
-				try {
-					ReflectionUtils.setFinalField(networkManager.getClass(), networkManager, fields[0], newRemoteAddress);
-				} catch (Exception e) {
-					ReflectionUtils.setFinalField(networkManager.getClass(), networkManager, fields[1], newRemoteAddress);
-				}
-			} else {
-				ReflectionUtils.setFinalField(networkManager.getClass(), networkManager, ConnectPlugin.getProtocol().getLoginNettyInjectHandlerNetworkManager(), newRemoteAddress);
-			}
-		} catch(Exception exception) {
-			exception.printStackTrace();
-		}
-		
-		// Submit to cache
-		this.payloadCache.submit(payload);
-	}
+    private String requestedStateFieldCache;
+    private String serverHostFieldCache;
 
-	public boolean isEnabled() {
-		return this.connectPlugin.isEnabled();
-	}
+    private ConnectPlugin connectPlugin;
+    private LoginPayloadCache payloadCache;
+
+    public LoginNettyInjectHandler(ConnectPlugin connectPlugin, LoginPayloadCache payloadCache) {
+        this.connectPlugin = connectPlugin;
+        this.payloadCache = payloadCache;
+    }
+
+    public void packetReceived(NettyDecoderHandler handler, ChannelHandlerContext context, Object object) throws Exception {
+        String packetName = object.getClass().getSimpleName();
+
+        if (packetName.startsWith("PacketHandshakingInSetProtocol")) {
+            handleSetProtocol(context, object);
+            return;
+        }
+
+        if (packetName.equals("PacketLoginInStart")) {
+            handlePacketLoginStart(context);
+            handler.setEnabled(false);
+            return;
+        }
+    }
+
+    private void handleSetProtocol(ChannelHandlerContext context, Object object) {
+        // Get requested state
+        try {
+            if (this.requestedStateFieldCache == null) {
+                for (Field field : object.getClass().getDeclaredFields()) {
+                    if (!field.getType().getSimpleName().equals("EnumProtocol")) {
+                        continue;
+                    }
+                    this.requestedStateFieldCache = field.getName();
+                    break;
+                }
+            }
+            Object requestedStateEnum = ReflectionUtils.getPrivateField(object.getClass(), object, Object.class, this.requestedStateFieldCache);
+            if (requestedStateEnum.toString().equals("STATUS")) {
+                return;
+            }
+        } catch (Exception exception) {
+            exception.printStackTrace();
+            context.close();
+            return;
+        }
+
+        // Get server host
+        String serverHost;
+        try {
+            if (this.serverHostFieldCache == null) {
+                for (Field field : object.getClass().getSuperclass().getDeclaredFields()) {
+                    if (!field.getType().getSimpleName().equals("String")) {
+                        continue;
+                    }
+                    this.serverHostFieldCache = field.getName();
+                    break;
+                }
+            }
+            serverHost = ReflectionUtils.getPrivateField(object.getClass().getSuperclass(), object, String.class, this.serverHostFieldCache);
+        } catch (Exception exception) {
+            exception.printStackTrace();
+            context.close();
+            return;
+        }
+
+        // Get login payload
+        LoginPayload payload;
+        try {
+            payload = LoginPayload.decode(serverHost);
+            if (payload == null) {
+                throw new Exception(); // for lack of a better solution
+            }
+        } catch (Exception exception) {
+            context.close();
+            return;
+        }
+
+        // Check the security key
+        if (!payload.getSecurityKey().equals(this.connectPlugin.getSecurityKey())) {
+            // TODO tell the client the security key failed?
+            context.close();
+            return;
+        }
+
+        // Store the host
+        try {
+            ReflectionUtils.setFinalField(object.getClass().getSuperclass(), object, this.serverHostFieldCache, payload.getHost());
+        } catch (Exception exception) {
+            exception.printStackTrace();
+        }
+
+        // Store the real ip & port
+        try {
+            InetSocketAddress newRemoteAddress = new InetSocketAddress(payload.getRealIp(), payload.getRealPort());
+            // Netty
+            ReflectionUtils.setFinalField(AbstractChannel.class, context.channel(), "remoteAddress", newRemoteAddress);
+            // MC
+            Object networkManager = context.channel().pipeline().get("packet_handler");
+
+            if (ConnectPlugin.getProtocol().getGeneralVersion().equalsIgnoreCase("1.7")) {
+                String[] fields = ConnectPlugin.getProtocol().getLoginNettyInjectHandlerNetworkManager().split(",");
+                try {
+                    ReflectionUtils.setFinalField(networkManager.getClass(), networkManager, fields[0], newRemoteAddress);
+                } catch (Exception e) {
+                    ReflectionUtils.setFinalField(networkManager.getClass(), networkManager, fields[1], newRemoteAddress);
+                }
+            } else {
+                ReflectionUtils.setFinalField(networkManager.getClass(), networkManager, ConnectPlugin.getProtocol().getLoginNettyInjectHandlerNetworkManager(), newRemoteAddress);
+            }
+
+        } catch (Exception exception) {
+            exception.printStackTrace();
+        }
+
+        // Submit to cache
+        this.payloadCache.submit(payload);
+    }
+
+    private void handlePacketLoginStart(ChannelHandlerContext context) {
+        // inject LoginListener
+        try {
+            Object networkManager = context.channel().pipeline().get("packet_handler");
+
+            Class loginListenerProxyClass = LoginListenerProxy.get(networkManager);
+            Constructor loginListenerProxyConstructor = loginListenerProxyClass.getConstructors()[0];
+
+            Object offlineMinecraftServer = OfflineInjector.getOfflineMinecraftServer();
+
+            Object loginListenerProxy = loginListenerProxyConstructor.newInstance(offlineMinecraftServer, networkManager);
+            loginListenerProxyClass.getField("injectUuidCallback").set(loginListenerProxy, (Runnable) () -> {
+                try {
+                    Field profileField = LoginListenerProxy.getProfileField();
+
+                    GameProfile profile = (GameProfile) profileField.get(loginListenerProxy);
+
+                    String name = profile.getName();
+                    LoginPayload payload = payloadCache.getByName(name);
+
+                    String uuidString = payload.getUUID();
+                    UUID uuid = UUID.fromString(uuidString.substring(0, 8) + "-" + uuidString.substring(8, 12) + "-" + uuidString.substring(12, 16) + "-" + uuidString.substring(16, 20) + "-" + uuidString.substring(20, 32));
+
+                    profile = new GameProfile(uuid, name);
+                    for (LoginPayload.Property payloadProperty : payload.getProperties()) {
+                        Property property = new Property(payloadProperty.getName(), payloadProperty.getValue(), payload.getSecurityKey());
+                        profile.getProperties().put(payloadProperty.getName(), property);
+                    }
+
+                    profileField.set(loginListenerProxy, profile);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            });
+
+            LoginListenerProxy.getPacketListenerField().set(networkManager, loginListenerProxy);
+        } catch (Exception exception) {
+            exception.printStackTrace();
+        }
+    }
+
+    public boolean isEnabled() {
+        return this.connectPlugin.isEnabled();
+    }
 
 }

--- a/src/main/java/lilypad/bukkit/connect/login/LoginNettyInjectHandler.java
+++ b/src/main/java/lilypad/bukkit/connect/login/LoginNettyInjectHandler.java
@@ -167,6 +167,9 @@ public class LoginNettyInjectHandler implements NettyInjectHandler {
                     }
 
                     profileField.set(loginListenerProxy, profile);
+
+                    Field hostnameField = LoginListenerProxy.getLoginListenerClass().getField("hostname");
+                    hostnameField.set(loginListenerProxy, payload.getHost());
                 } catch (Exception e) {
                     e.printStackTrace();
                 }

--- a/src/main/java/lilypad/bukkit/connect/util/JavassistUtil.java
+++ b/src/main/java/lilypad/bukkit/connect/util/JavassistUtil.java
@@ -1,0 +1,26 @@
+package lilypad.bukkit.connect.util;
+
+import javassist.ClassPool;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Paths;
+
+public class JavassistUtil {
+    public static ClassPool getClassPool() {
+        ClassPool classPool = ClassPool.getDefault();
+
+        URLClassLoader classLoader = (URLClassLoader) Thread.currentThread().getContextClassLoader();
+        for (URL url : classLoader.getURLs()) {
+            try {
+                // assume files
+                String path = Paths.get(url.toURI()).toString();
+                classPool.appendClassPath(path);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+        System.out.println();
+        return classPool;
+    }
+}


### PR DESCRIPTION
Replace the method used to inject the GameProfile with a (hopfully) better solution.
The way this works is by generating a class that extends LoginListener and hooks the method that handles generating the offline profile.
This allows for earlier injection of the GameProfile avoiding the offline UUID version of the player ever existing.
